### PR TITLE
Add new required rule for uptime

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-instance.yaml
+++ b/.github/ISSUE_TEMPLATE/add-instance.yaml
@@ -21,6 +21,8 @@ body:
         required: true
       - label: "I won't try to manipulate the ranking of my instance in a way that give an unfair advantage over the other public instances in the list. (e.g. caching requests for searx.space server)"
         required: true
+      - label: "I guarantee to keep an uptime per month of my instance at **minimum 90%**. Your instance will be removed if you don't respect this rule."
+        required: true
 
   - type: dropdown
     id: version


### PR DESCRIPTION
This allows to not have public instances that are down half of the month. I know searx.space doesn't list the instances that are down, but at least people won't pick instances that are down too much time per month.

90% is 3d per month of downtime: https://uptime.is/90 which IMO already too much but that's what Invidious has and we stopped having broken instances all over the place after requiring this rule. Or should we reduce to 85% or 80%? idk tell me your opinion on this