### PR TITLE
Forbid more hosting types that are bad for privacy

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-instance.yaml
+++ b/.github/ISSUE_TEMPLATE/add-instance.yaml
@@ -35,14 +35,17 @@ body:
         required: true
       - label: "I won't try to manipulate the ranking of my instance in a way that give an unfair advantage over the other public instances in the list. (e.g. caching requests for searx.space server)"
         required: true
+      - label: "I control the final webserver that is serving the requests to the users of my instance. Here is a non-exhaustive list of forbidden hosting types: PaaS, managed HTTP load balancers (e.g. AWS ALB), Cloudflare, shared Web hosting."
+        required: true
 
   - type: markdown
     attributes:
       value: |
         ### Recommendations for your instance
 
-        - Try to not use Cloudflare or any other commercial solution that analyze the HTTP traffic between the user and the server.
-          It's bad for the privacy because the provider can see all the HTTP traffic between the users and your server.
+        - Do not use Cloudflare or any other commercial solution that analyze the HTTP traffic between the user and the server.
+          It's forbidden because you are not in control of the final webserver.
+          Also, it's bad for the privacy because the provider can see all the HTTP traffic between the users and your server.
           Prefer using [the built-in limiter plugin](https://docs.searxng.org/src/searx.plugins.limiter.html#limiter-plugin) for SearxNG or [filtron](https://github.com/searxng/filtron) for SearX.
         - Don't block JavaScript users with CAPTCHA that only work with JavaScript, page that verify the user with JavaScript and so on.
         - Try to harden the TLS security of your server by getting an A+ TLS grade on https://cryptcheck.fr.


### PR DESCRIPTION
Do not allow public instances where the owner doesn't control the final webserver that is serving the HTTPS requests to the users of the instance.

This avoids any potential issues where the owner of the instance can't tune their TLS configuration for example, see https://github.com/searxng/searx-instances/issues/220#issuecomment-1295139045.
And add more privacy for the users because the hosting provider (not the owner) won't be able to easily eavesdrop on the users of the instance.

Non-exhaustive list of forbidden hosting types: PaaS, managed HTTP load balancers (e.g. AWS ALB), Cloudflare, shared Web hosting.

Special note to @ononoki1, when this PR will be merged, any request for adding an instance hosted on Cloudflare will be denied.

-----

How to spot a public instance hosted on a PaaS or HTTP loadbalancer:
Look at the HTTP headers returned, for example AWS ALB will return these additional headers: https://www.repost.aws/questions/QUhc8bF_OUQyy1u7lqbedZhw/what-are-the-headers-added-by-alb
Or look at the server name from the HTTP header `Server`, for cloudflare it will be `Server: cloudflare`.
Or look at the whois of the IP address of the instance, for cloudflare it will be `Cloudflare, Inc.`: https://www.iplocation.net

----

https://github.com/searxng/searx-instances/pull/224 will have to be merged when this PR is merged.