### PR TITLE
search.zzls.xyz -> search.nadeko.net

### DIFF
--- a/searxinstances/instances.yml
+++ b/searxinstances/instances.yml
@@ -40,9 +40,9 @@ https://search.rowie.at: {}
 https://search.sapti.me: {}
 https://search.smnz.de: {}
 https://search.upinmars.com: {}
-https://search.zzls.xyz:
+https://search.nadeko.net:
   additional_urls:
-    http://searxdr3pqz4nydgnqocsia2xbywptxbkympa2emn7zlgggrir4bkfad.onion: Hidden Service
+    http://search.nadekonfkhwlxwwk4ycbvq42zvcjmvo5iakl4tajojjwxd4a5dcetuyd.onion: Hidden Service
 https://searx.ankha.ac: {}
 https://searx.baczek.me: {}
 https://searx.be: {}


### PR DESCRIPTION
Old URL still works perfectly. Tor address changed too.

Fixes https://github.com/searxng/searx-instances/issues/460