### PR TITLE
Update guidelines to include a 2-week hold

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-instance.yaml
+++ b/.github/ISSUE_TEMPLATE/add-instance.yaml
@@ -16,6 +16,8 @@ body:
         Your instance will receive requests from the host `check.searx.space` (the IP addresses of this host may change in the future).
         Currently, if you don't give the right to `check.searx.space` to check your instance, it is not possible to add your instance to the list.
 
+        New instance requests are subject to a 2-week hold before being added. This period helps verify the maintainer keeps the instance healthy and up to date.
+
   - type: checkboxes
     attributes:
       label: Requirements (make sure to read all of them)

--- a/.github/workflows/detect-previous-instance.yml
+++ b/.github/workflows/detect-previous-instance.yml
@@ -48,8 +48,7 @@ jobs:
               await exec.exec('git', ['log', '-S', instanceHostname, '--pretty=format:Commit ID: %H%n - Date: %ad%n - Description: %s%n - Author: %an%n'], options);
               if (myOutput !== "") {
                 var replyComment =
-                  ['@maintainers Warning, instance found in the commit history, make sure to wait 1 week before adding the instance if needed.',
-                  'See here for more information: https://github.com/searxng/searx-instances#add-a-previously-submitted-instance',
+                  ['@maintainers - instance found in the commit history.',
                   '',
                   '```',
                   ].join('\n');

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ https://nibblehole.com: {}
 
 Here is it possible to modify the yaml, the commit message and validate or delete the whole buffer to cancel.
 
-### Add a previously submitted instance
+### 2-week hold for new instances
 
-Was discussed in https://github.com/searxng/searx-instances/discussions/150
+All new instance requests must wait 2 weeks before being added. Apply the `wait-2-weeks` label when an instance has been deemed ready for addition. After 2 weeks, verify the instance has been kept up to date before adding it to the list.
 
-1. Look in the commit history if the instance was already added and got removed due to errors or bad uptime.
-   The bot may help you with that.
-2. If the instance was previously removed only once for bad uptime or errors then add the domain on https://github.com/searxng/searx-instances-uptime/blob/master/.upptimerc-custom.yml.
-  But if the instance was removed multiple times, do not add the instance or make an exception in exceptional cases.
-3. Add the label `wait-1-week`.
-4. If the uptime is more than 95% (8 hours) after 1 week the instance can be normally added back and remove it from the custom file.  
-   If not do not add the instance.
+### Adding a previously submitted instance
+
+This applies only to instances that were previously added to the list and later removed (e.g. due to errors or bad uptime):
+
+1. Add the domain to the uptime tracker custom list to monitor stability: https://github.com/searxng/searx-instances-uptime/blob/master/.upptimerc-custom.yml
+2. Follow the general 2-week hold.
+3. After this period, verify the instance has been kept up to date and meets the uptime requirement of >95% (16.8h). If it does, it can be added back and removed from the custom list. If not, do not add the instance.


### PR DESCRIPTION
I'm seeing a lot of public instances where the maintainer doesn't have a cron job / watchtower to automatically update.

> I'll keep my instance up to date, at the very least **1 week old**.

This PR adds a 2 week hold to new instance requests to verify that the maintainer can keep their instances up to date.

Similar projects like invidious have a month hold for their new instances.