### PR TITLE
docs: reword instance addition template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-instance.yaml
+++ b/.github/ISSUE_TEMPLATE/add-instance.yaml
@@ -11,76 +11,60 @@ body:
       value: |
         ### General
 
-        Enter your instance URL in the title above ( For example: `Add https://searxng.example.com` )
+        Enter your instance URL in the title above e.g: `Add https://searxng.example.com`
 
-        Your instance will receive requests from the host `check.searx.space` (the IP addresses of this host may change in the future).
-        Currently, if you don't give the right to `check.searx.space` to check your instance, it is not possible to add your instance to the list.
+        ---
 
-        New instance requests are subject to a 2-week hold before being added. This period helps verify the maintainer keeps the instance healthy and up to date.
+        Your instance will receive requests from the host `check.searx.space`:
+
+        The IP addresses may change in the future, currently they are:
+        - 167.235.158.251
+        - 2a01:04f8:1c1c:8fc2::/64
+
+        New instance requests are subject to a 2 week wait after approval to ensure the maintainer can keep their instance healthy and up to date.
 
   - type: checkboxes
     attributes:
       label: Requirements (make sure to read all of them)
       description: |
-        If you don't respect all the requirements your instance can't be added.
-        And if later after we add your instance, we found out that your instance fail to respect all requirements, we will remove it.
-        We may in the future adapt these rules, but you will be notified if your instance fails to respect the new rules.
+        You must comply with all the requirements for your instance to be added. If after we add your instance, it fails to respect all requirements, it will be removed.
+        We also may modify these rules in the future, although you will be notified if your instance fails to respect the new requirements.
       options:
-      - label: "It is my instance. I bought the domain myself and I own this domain. Free domains (e.g. Freenom) and shared domains (e.g. noip.com) are not allowed."
+      - label: "This is my instance. I bought and own this domain myself. Shared domains (e.g. noip.com, eu.org) are not allowed."
         required: true
-      - label: "I'll keep my instance up to date, at the very least 1 week old. Example program for keeping up to date: watchtower, cron, ouroboros."
+      - label: "I'll keep my instance up to date (no more than 1 week behind). Examples: watchtower, cron, diun, wud."
         required: true
-      - label: "I give the right to `check.searx.space` to check my instance (every 3 hours for the response times, every 24 hours for the other tests)."
-        required: true
-      - label: "I acknowledge that managing a public instance is not an easy task and require spending time to keep the instance in good health. E.g. look after your instance by using a monitoring system."
-        required: true
-      - label: "I guarantee to keep an uptime per month of my instance at **minimum 90%**. Please ask for a removal of your instance if there is a planned long downtime or notify us [here](https://github.com/searxng/searx-instances/discussions/categories/report-instance-downtime) for a short downtime."
+      - label: "I will keep at least **90%** monthly uptime. If a long downtime is planned (7d+), ask for the instance to be removed."
         required: true
       - label: "I do not track the users of my instance with any analytics or tracking software."
         required: true
-      - label: "I won't try to manipulate the ranking of my instance in a way that give an unfair advantage over the other public instances in the list. (e.g. caching requests for searx.space server)"
+      - label: "I won't manipulate my instance ranking to gain an unfair advantage over other public instances (e.g. caching requests from searx.space)."
         required: true
-      - label: "I control the final webserver (software) that is serving the requests to the users of my instance. Here is a non-exhaustive list of forbidden hosting types: Cloudflare, PaaS, managed (hosting provider controlled) HTTP(S) load balancer (e.g. AWS ALB), shared Web hosting. TCP load balancer is fine. Cloudflare DNS only (grey cloud) is fine."
+      - label: "I control the webserver that terminates TLS for user requests. Examples of forbidden services: Cloudflare Proxy (orange cloud), PaaS (e.g. Heroku, Railway, Render), managed HTTP(S) load balancers (e.g. AWS ALB, Google Cloud HTTPS LB), shared web hosting. Examples of allowed services: TCP/L4 load balancers, Cloudflare DNS only (grey cloud)."
         required: true
-      - label: "If needed, I can restrict users from accessing my instance for the only sole reason of keeping my instance in working conditions for the other users ([detailed description](https://github.com/searxng/searx-instances/pull/346) - evidence need to be provided when asked). Other means of restriction is forbidden."
+      - label: "I acknowledge that managing a public instance is not an easy task and takes ongoing work to keep the instance healthy. (e.g. using a monitoring system)"
+        required: true
+      - label: "I will only restrict user access when needed to keep the instance working for everyone else (e.g. bots, attacks). Restrictions for other reasons are forbidden."
+        required: true
+
+  - type: checkboxes
+    attributes:
+      label: Bot protection
+      description: |
+        You must enable the `server.public_instance` parameter. [Documentation](https://github.com/searxng/searx-instances/discussions/417)
+      options:
+      - label: "Yes I have configured the `server.public_instance` parameter."
         required: true
 
   - type: markdown
     attributes:
       value: |
-        ### Recommendations for your instance
-
-        - Do not use Cloudflare or any other commercial solution that analyze the HTTP traffic between the user and the server.
-          It's forbidden because you are not in control of the final webserver.
-          Also, it's bad for the privacy because the provider can see all the HTTP traffic between the users and your server.
-          Prefer using [the built-in limiter plugin](https://docs.searxng.org/src/searx.plugins.limiter.html#limiter-plugin).
-        - Don't block JavaScript users with CAPTCHA that only work with JavaScript, page that verify the user with JavaScript and so on.
-        - Try to harden the TLS security of your server by getting an A+ TLS grade on https://cryptcheck.fr.
-          You can use https://ssl-config.mozilla.org to get A+ TLS grade.
-        - Try to harden the security of your users when they use your instance by getting an A+ CSP grade on https://observatory.mozilla.org.
-          Look into https://github.com/searxng/searx-docker/blob/master/Caddyfile#L33-L84 to get A+ CSP grade.
-        - Configure IPv6 on your server, if your provider supports it please enable it. The future of the internet will thank you, see [why here](https://old.reddit.com/r/explainlikeimfive/comments/1k45y7/eli5_what_is_ipv6_and_why_is_it_so_important/).
-
-  - type: checkboxes
-    attributes:
-      label: Bot protection requirement
-      description: |
-        Please enable the `server.public_instance` parameter as explained in this documentation: https://github.com/searxng/searx-instances/discussions/417
-        We can make exceptions in case you really do not want to enable our bot limiter solution, but you will have to send us proofs as a comment in the issue:
-        clearly stating how you detect bots, how you actively deal with them and also prove that it really works.
-      options:
-      - label: "Yes I have configured the `server.public_instance` parameter."
-        required: true
-
-  - type: input
-    id: source-code-url
-    attributes:
-      label: Source code URL
-      description: |
-        If you have modified the source code, please publish it to an URL and make sure that the URL is publicly accessible in your instance's site
-        In case of issue, please specify the GIT URL here
-    validations:
-      required: false
+        ### Recommendations for your instance (rank higher on searx.space)
+        - Harden the TLS security of your server by getting an [A+ TLS grade](https://cryptcheck.fr/).
+          Look into the [TLS & CSP guide](https://github.com/searxng/searx-instances/discussions/849)
+        - Harden the security of your users when they use your instance by getting an [A+ CSP grade](https://observatory.mozilla.org/).
+          Look into the [TLS & CSP guide](https://github.com/searxng/searx-instances/discussions/849)
+        - Configure IPv6 on your server: if your provider supports it, please enable it - the internet will thank you.
 
   - type: input
     id: matrix-username
@@ -90,8 +74,17 @@ body:
         Please enter your full Matrix ID, including your homeserver.
         Example: @foobar:matrix.org
         
-        By providing your Matrix username, you will receive an invite to the private instance owners room. 
+        You will receive an invite to the private instance owners room. 
         We discuss the troubles of managing a public instance, share advice (like how to defend your instance against bots), and also announce any big changes to searxng that may affect you.
+    validations:
+      required: false
+
+  - type: input
+    id: source-code-url
+    attributes:
+      label: Alternate source code
+      description: |
+        If you have modified SearXNG, publish your changes and make sure that they are accessible from your instance in order to comply with the AGPL.
     validations:
       required: false
 


### PR DESCRIPTION
Clean up of the issue addition template to rewrite it as a native english speaker and to remove some old parts that aren't relevant anymore.

- list the current `check.searx.space` IPs as more people are needing this information when setting up external bot detection like anubis.
- require `server.public_instance`, it was already required for some time now.
- point the TLS/CSP recommendations at #849 and removed the two dead links.
- clean up alternate source code field.
- stopped asking instances to report short downtimes because we are doing nothing with this information anyways

No public instance will be affected by these changes, it is mostly just a polish